### PR TITLE
Multi annotation

### DIFF
--- a/napari_organoid_counter/_utils.py
+++ b/napari_organoid_counter/_utils.py
@@ -63,7 +63,7 @@ def write_to_json(name, data):
         json.dump(data, outfile)  
 
 def get_bboxes_as_dict(bboxes, bbox_ids, scores, scales, labels):
-    """ Write all data, boxes, ids and scores and scale, to a dict so we can later save as a json """
+    """ Write all data, boxes, ids and scores, scale and class label, to a dict so we can later save as a json """
     data_json = {} 
     for idx, bbox in enumerate(bboxes):
         x1, y1 = bbox[0]

--- a/napari_organoid_counter/_utils.py
+++ b/napari_organoid_counter/_utils.py
@@ -62,12 +62,13 @@ def write_to_json(name, data):
     with open(name, 'w') as outfile:
         json.dump(data, outfile)  
 
-def get_bboxes_as_dict(bboxes, bbox_ids, scores, scales):
+def get_bboxes_as_dict(bboxes, bbox_ids, scores, scales, labels):
     """ Write all data, boxes, ids and scores and scale, to a dict so we can later save as a json """
     data_json = {} 
     for idx, bbox in enumerate(bboxes):
         x1, y1 = bbox[0]
         x2, y2 = bbox[2]
+
         data_json.update({str(bbox_ids[idx]): {'box_id': str(bbox_ids[idx]),
                                                 'x1': str(x1),
                                                 'x2': str(x2),
@@ -75,7 +76,8 @@ def get_bboxes_as_dict(bboxes, bbox_ids, scores, scales):
                                                 'y2': str(y2),
                                                 'confidence': str(scores[idx]),
                                                 'scale_x': str(scales[0]),
-                                                'scale_y': str(scales[1])
+                                                'scale_y': str(scales[1]),
+                                                'class': labels[idx]
                                                 }
                         })
     return data_json

--- a/napari_organoid_counter/_widget.py
+++ b/napari_organoid_counter/_widget.py
@@ -136,16 +136,14 @@ class OrganoidCounterWidget(QWidget):
                 if len(selected_shapes) > 0:
                     # Modify the edge color only for the selected shapes
                     current_edge_colors = self.cur_shapes_layer.edge_color 
-                    changed_indices = []  # To collect all changed indices
                     for idx in selected_shapes:
                         # Save original color
                         # if idx not in self.original_colors: 
                             # self.original_colors[idx] = current_edge_colors[idx].copy()
                         # Update to the new color
                         current_edge_colors[idx] = settings.COLOR_CLASS_1
-                        changed_indices.append(idx)  # Add the index to the list
                     self.cur_shapes_layer.edge_color = current_edge_colors  # Apply the changes
-                    show_info(f"Changed edge color of shapes {changed_indices} to green.")
+                    show_info(f"Changed edge color of shapes {list(selected_shapes)} to green.")
                 else:
                     show_warning("No shapes selected to change edge color.")
 
@@ -160,16 +158,14 @@ class OrganoidCounterWidget(QWidget):
                 if len(selected_shapes) > 0:
                     # Modify the edge color only for the selected shapes
                     current_edge_colors = self.cur_shapes_layer.edge_color
-                    changed_indices = [] # To collect all changed indices
                     for idx in selected_shapes:
                         # Save original color
                         # if idx not in self.original_colors: 
                             # self.original_colors[idx] = current_edge_colors[idx].copy()
                         # Update to the new color
                         current_edge_colors[idx] = settings.COLOR_CLASS_2
-                        changed_indices.append(idx)  # Add the index to the list
                     self.cur_shapes_layer.edge_color = current_edge_colors  # Apply the changes
-                    show_info(f"Changed edge color of {changed_indices} to blue.")
+                    show_info(f"Changed edge color of {list(selected_shapes)} to blue.")
                 else:
                     show_warning("No shapes selected to change edge color.")
 
@@ -183,18 +179,14 @@ class OrganoidCounterWidget(QWidget):
                 selected_shapes = self.cur_shapes_layer.selected_data
                 if len(selected_shapes) > 0:
                     current_edge_colors = self.cur_shapes_layer.edge_color
-                    # Set the edge color back to magenta 
-                    new_edge_color = [1., 0, 1., 1.]  # RGBA for magenta
                     # Modify the edge color only for the selected shapes
                     current_edge_colors = self.cur_shapes_layer.edge_color
-                    changed_indices = [] # To collect all changed indices
                     for idx in selected_shapes:
                         # if idx in self.original_colors:
                             # Revert to the original color
-                            current_edge_colors[idx] = new_edge_color
-                            changed_indices.append(idx)  # Add the index to the list
+                            current_edge_colors[idx] = settings.COLOR_DEFAULT
                     self.cur_shapes_layer.edge_color = current_edge_colors  # Apply the changes
-                    show_info(f"Reset edge color of {changed_indices} to magenta.")
+                    show_info(f"Reset edge color of {list(selected_shapes)} to magenta.")
                 else:
                     show_warning("No shapes selected to reset edge color.")
 
@@ -295,7 +287,7 @@ class OrganoidCounterWidget(QWidget):
                                                                face_color='transparent',  
                                                                properties = properties,
                                                                text = text_params,
-                                                               edge_color='magenta',
+                                                               edge_color=settings.COLOR_DEFAULT,
                                                                shape_type='rectangle',
                                                                edge_width=12) # warning generated here
                             

--- a/napari_organoid_counter/_widget.py
+++ b/napari_organoid_counter/_widget.py
@@ -537,9 +537,9 @@ class OrganoidCounterWidget(QWidget):
             # Assign organoid label based on edge_color
             for edge_color in edge_colors:
                 if np.allclose(edge_color[:3], green[:3]):
-                    labels.append(1)  # Label for green
+                    labels.append(0)  # Label for green
                 elif np.allclose(edge_color[:3], blue[:3]):
-                    labels.append(2)  # Label for blue
+                    labels.append(1)  # Label for blue
                 else:
                     raise ValueError(f"Unexpected edge color {edge_color[:3]} encountered.")
 

--- a/napari_organoid_counter/_widget.py
+++ b/napari_organoid_counter/_widget.py
@@ -3,8 +3,12 @@ from typing import List
 from skimage.io import imsave
 from datetime import datetime
 
+import napari
+
 from napari import layers
 from napari.utils.notifications import show_info
+
+import numpy as np
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QApplication, QDialog, QFileDialog, QGroupBox, QHBoxLayout, QLabel, QComboBox, QPushButton, QLineEdit, QProgressBar, QSlider
@@ -112,9 +116,86 @@ class OrganoidCounterWidget(QWidget):
         self.viewer.layers.events.inserted.connect(self._added_layer)
         self.viewer.layers.events.removed.connect(self._removed_layer)
         self.viewer.layers.selection.events.changed.connect(self._sel_layer_changed)
+    
         # setup flags used for changing slider and text of min diameter and confidence threshold
         self.diameter_slider_changed = False 
-        self.confidence_slider_changed = False 
+        self.confidence_slider_changed = False
+
+        # Key binding to return the ID of the bounding boxes selected from the GUI
+        @self.viewer.bind_key('s')
+        def selected_boxes(viewer: napari.Viewer):
+            if self.cur_shapes_layer is not None:  # Check if there is a valid shapes layer selected
+                selected_shapes = self.cur_shapes_layer.selected_data
+                print(f"Selected shapes indices: {selected_shapes}")
+
+        # Dictionary where key are shape indices and values are RGBA colors
+        self.original_colors = {}
+
+        # Key binding to change the edge_color of the bounding boxes to green
+        @self.viewer.bind_key('g')
+        def change_edge_color_to_green(viewer: napari.Viewer):
+            if self.cur_shapes_layer is not None:  # Ensure shapes layer exists
+                selected_shapes = self.cur_shapes_layer.selected_data # Retrieves indices of shapes currently selected, returns a set 
+                if len(selected_shapes) > 0:
+                    # Set the edge color of selected shapes to green
+                    new_edge_color = [85/255, 1., 0, 1.]  # RGBA for green
+                    # Modify the edge color only for the selected shapes
+                    current_edge_colors = self.cur_shapes_layer.edge_color 
+                    for idx in selected_shapes:
+                        # Save original color
+                        if idx not in self.original_colors: 
+                            self.original_colors[idx] = current_edge_colors[idx].copy()
+                        # Update to the new color
+                        current_edge_colors[idx] = new_edge_color
+
+                    self.cur_shapes_layer.edge_color = current_edge_colors  # Apply the changes
+                    print(f"Changed edge color of {idx} to {new_edge_color}")
+                else:
+                    print("No shapes selected to change edge color.")
+
+        # Key binding to change the edge_color of the bounding boxes to blue
+        @self.viewer.bind_key('h')
+        def change_edge_color_to_blue(viewer: napari.Viewer):
+            if self.cur_shapes_layer is not None:  # Ensure shapes layer exists
+                selected_shapes = self.cur_shapes_layer.selected_data
+                if len(selected_shapes) > 0:
+                    # Set the edge color of selected shapes to green
+                    new_edge_color = [0, 29/255, 1., 1.]  # RGBA for blue
+                    # Modify the edge color only for the selected shapes
+                    current_edge_colors = self.cur_shapes_layer.edge_color
+                    for idx in selected_shapes:
+                        # Save original color
+                        if idx not in self.original_colors: 
+                            self.original_colors[idx] = current_edge_colors[idx].copy()
+                        # Update to the new color
+                        current_edge_colors[idx] = new_edge_color
+                    self.cur_shapes_layer.edge_color = current_edge_colors  # Apply the changes
+                    print(f"Changed edge color of {idx} to {new_edge_color}")
+                else:
+                    print("No shapes selected to change edge color.")
+
+        # Key binding to reset the edge_color of selected bounding boxes to their original color
+        @self.viewer.bind_key('z')
+        def reset_edge_color(viewer: napari.Viewer):
+            if self.cur_shapes_layer is not None:  # Ensure shapes layer exists
+                selected_shapes = self.cur_shapes_layer.selected_data
+                if len(selected_shapes) > 0:
+                    current_edge_colors = self.cur_shapes_layer.edge_color
+
+                    for idx in selected_shapes:
+                        if idx in self.original_colors:
+                            # Revert to the original color
+                            current_edge_colors[idx] = self.original_colors[idx]
+                            # Remove from the dictionary after reverting
+                            del self.original_colors[idx]
+                        else:
+                            print(f"No original color stored for shape {idx}, skipping reset.")
+
+                    self.cur_shapes_layer.edge_color = current_edge_colors  # Apply the changes
+                    print(f"Reset edge color of {idx} to their original color.")
+                else:
+                    print("No shapes selected to reset edge color.")
+
 
     def handle_progress(self, blocknum, blocksize, totalsize):
         """ When the model is being downloaded, this method is called and th progress of the download
@@ -218,6 +299,7 @@ class OrganoidCounterWidget(QWidget):
                             
             # set current_edge_width so edge width is the same when users annotate - doesnt' fix new preds being added!
             self.viewer.layers[labels_layer_name].current_edge_width = 12
+            
 
     def _on_preprocess_click(self):
         """ Is called whenever preprocess button is clicked """
@@ -423,10 +505,41 @@ class OrganoidCounterWidget(QWidget):
         #scores = #add
         if not bboxes: show_info('No organoids detected! Please run auto organoid counter or run algorithm first and try again!')
         else:
+            # Get the edge colors for all bounding boxes
+            edge_colors = self.cur_shapes_layer.edge_color
+            labels = []
+
+            # Check if all bounding boxes have their edge color set (not green or blue)
+            green = np.array([85/255, 1., 0, 1.])
+            blue = np.array([29/255, 0, 1., 1.])
+
+            all_colored = True
+            for edge_color in edge_colors:
+                # Compare the colors with a tolerance using np.allclose to account for floating-point errors
+                if not (np.allclose(edge_color[:3], green[:3]) or np.allclose(edge_color[:3], blue[:3])):
+                    all_colored = False
+                    break
+
+            if not all_colored:
+                show_info('Please change the color of all bounding boxes before saving.')
+                return
+            
+            # Assign organoid label based on edge_color
+            for edge_color in edge_colors:
+                if np.allclose(edge_color[:3], green[:3]):
+                    labels.append(0)  # Label for green
+                elif np.allclose(edge_color[:3], blue[:3]):
+                    labels.append(1)  # Label for blue
+                else:
+                    labels.append(-1)  # Label for other colors
+
             data_json = utils.get_bboxes_as_dict(bboxes, 
-                                           self.viewer.layers[self.save_layer_name].properties['box_id'],
-                                           self.viewer.layers[self.save_layer_name].properties['scores'],
-                                           self.viewer.layers[self.save_layer_name].scale)
+                                        self.viewer.layers[self.save_layer_name].properties['box_id'],
+                                        self.viewer.layers[self.save_layer_name].properties['scores'],
+                                        self.viewer.layers[self.save_layer_name].scale,
+                                        labels=labels)
+            
+        
             # write bbox coordinates to json
             fd = QFileDialog()
             name,_ = fd.getSaveFileName(self, 'Save File', self.save_layer_name, 'JSON files (*.json)')#, 'CSV Files (*.csv)')
@@ -471,7 +584,8 @@ class OrganoidCounterWidget(QWidget):
         self.organoiDL.update_bboxes_scores(self.cur_shapes_name,
                                             self.cur_shapes_layer.data,
                                             self.cur_shapes_layer.properties['scores'],
-                                            self.cur_shapes_layer.properties['box_id'])
+                                            self.cur_shapes_layer.properties['box_id']
+                                            )
         self.cur_shapes_layer.events.data.connect(self.shapes_event_handler)
         
     def _update_remove_shapes(self, removed_layers):
@@ -507,6 +621,7 @@ class OrganoidCounterWidget(QWidget):
                 new_ids[-1] = self.organoiDL.next_id[self.cur_shapes_name]
                 new_scores = self.viewer.layers[self.cur_shapes_name].properties['scores']
                 new_scores[-1] = 1
+    
             # set new properties to shapes layer
             self.viewer.layers[self.cur_shapes_name].properties ={'box_id': new_ids,'scores':  new_scores}
             # refresh text displayed

--- a/napari_organoid_counter/settings.py
+++ b/napari_organoid_counter/settings.py
@@ -48,5 +48,8 @@ def init():
     global COLOR_CLASS_2
     COLOR_CLASS_2 = [0, 29 / 255, 1.0, 1.0]  # Blue
 
+    global COLOR_DEFAULT
+    COLOR_DEFAULT = [1., 0, 1., 1.] # Magenta
+
 
 

--- a/napari_organoid_counter/settings.py
+++ b/napari_organoid_counter/settings.py
@@ -38,7 +38,15 @@ def init():
         "rtmdet":  {"source": "https://zenodo.org/records/11388549/files/rtmdet_l_organoid.py",
                     "destination": ".mim/configs/rtmdet/rtmdet_l_organoid.py"
                     }
+
 }
+    
+    # Add color definitions
+    global COLOR_CLASS_1
+    COLOR_CLASS_1 = [85 / 255, 1.0, 0, 1.0]  # Green
+    
+    global COLOR_CLASS_2
+    COLOR_CLASS_2 = [0, 29 / 255, 1.0, 1.0]  # Blue
 
 
 


### PR DESCRIPTION
This pull request introduces a dropdown menu that allows users to toggle between two modes: 
**Single Annotation Mode:** in this mode, the color of the bounding boxes remains fixed and cannot be changed.
**Multi-Annotation Mode:** users can change the color of the bounding boxes using the following keyboard shortcuts:
- Press 'G' to change the box color to green.
- Press 'H' to change the box color to blue.
- Press 'Z' to reset the bounding box to its original color.
When the 'Save Boxes' button is clicked, the class label of the organoid is determined based on the bounding box color:
- Class Label 0 for green.
- Class Label 1 for blue.
